### PR TITLE
v1.0.2-M1

### DIFF
--- a/core-app/src/index.html
+++ b/core-app/src/index.html
@@ -17,8 +17,8 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="apple-touch-icon" href="assets/icons/icon-192x192.png">
 
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400&amp;display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons&amp;display=swap" rel="stylesheet">
+  <link disabled href="https://fonts.googleapis.com/css?family=Roboto:300,400&amp;display=swap" rel="stylesheet" media="screen">
+  <link disabled href="https://fonts.googleapis.com/icon?family=Material+Icons&amp;display=swap" rel="stylesheet" media="screen">
 
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#1976d2">


### PR DESCRIPTION
This eliminates blocking issue for google fonts and material icons css files. 

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] code style update
- [ ] build related changes
- [ ] other

**Does this PR introduce a breaking change ?**
- [ ] Yes
- [x] No

**Before - After**
- before 
![before](https://user-images.githubusercontent.com/25284531/62932210-63facb00-bdc8-11e9-838b-efbb82d3bdaa.jpeg)

- after 
1st measure
<img width="1302" alt="after googlefont and material icon disabled download 3rd measure" src="https://user-images.githubusercontent.com/25284531/62932024-0bc3c900-bdc8-11e9-8cc1-f7faebd995e1.png">

2nd measure
<img width="1321" alt="after googlefont and material icon disabled download 2nd measure" src="https://user-images.githubusercontent.com/25284531/62932137-4168b200-bdc8-11e9-87c0-3e15d6d9b611.png">

3rd measure
<img width="1321" alt="after googlefont and material icon disabled download" src="https://user-images.githubusercontent.com/25284531/62932147-46c5fc80-bdc8-11e9-9847-3468bee865f9.png">




